### PR TITLE
Try to load native libraries without modifying host system first

### DIFF
--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -301,7 +301,7 @@ public class SerialNativeInterface {
         try {
             System.loadLibrary(lib);
             return true;
-        } catch (Exception e) {
+        } catch (UnsatisfiedLinkError e) {
             return false;
         }
     }

--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -150,7 +150,9 @@ public class SerialNativeInterface {
 
         boolean loadLib = false;
 
-        if(isLibFolderExist(libFolderPath)){
+        if(loadLibFromPath("jSSC-"+libVersion)) {
+            // nothing more to do
+        } else if(isLibFolderExist(libFolderPath)){
             if(isLibFileExist(libFolderPath + fileSeparator + libName)){
                 loadLib = true;
             }
@@ -287,6 +289,21 @@ public class SerialNativeInterface {
      */
     public static String getLibraryMinorSuffix() {
         return libMinorSuffix;
+    }
+
+    /**
+     * Attempt to load a library using System.loadLibrary
+     *
+     * @param lib name of the library
+     * @return true if successful, false if not
+     */
+    public static boolean loadLibFromPath(String lib) {
+        try {
+            System.loadLibrary(lib);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Before dynamically extracting the matching native library, attempt to load it first via System.loadLibrary(). This can be used when it's not desired to modify the host system (but rather change java.library.path accordingly.
