### PR TITLE
Changed blocking calls so they can be stopped with thread.interrupt()

### DIFF
--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -390,8 +390,9 @@ public class SerialNativeInterface {
      * @param byteCount count of bytes required to read
      * 
      * @return Method returns the array of read bytes
+     * @throws InterruptedException if the java thread is interrupted while blocking 
      */
-    public native byte[] readBytes(long handle, int byteCount);
+    public native byte[] readBytes(long handle, int byteCount) throws InterruptedException;
 
     /**
      * Write data to port

--- a/src/java/jssc/SerialPort.java
+++ b/src/java/jssc/SerialPort.java
@@ -418,7 +418,11 @@ public class SerialPort {
      */
     public byte[] readBytes(int byteCount) throws SerialPortException {
         checkPortOpened("readBytes()");
-        return serialInterface.readBytes(portHandle, byteCount);
+        try {
+            return serialInterface.readBytes(portHandle, byteCount);
+        } catch (InterruptedException e) {
+            throw new SerialPortException(portName, "readBytes", SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
+        }
     }
 
     /**
@@ -543,7 +547,7 @@ public class SerialPort {
                 Thread.sleep(0, 100);//Need to sleep some time to prevent high CPU loading
             }
             catch (InterruptedException ex) {
-                //Do nothing
+                throw new SerialPortException(portName, methodName, SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
             }
         }
         if(timeIsOut){


### PR DESCRIPTION
Changed the native read functions to poll the java thread's interrupt status.  If the thread has been interrupted at a high level with thread.interrupt(), then the unlimited blocking read call as well as the timeout read call will throw an exception almost immediately.

The benefit of this is that an application can close cleanly and quickly whenever it wants, instead of waiting for the timeout to elapse in the case of timed reads, or waiting a long time (or forever) for the indefinite reads.

Tested on Debian Wheezy x64 and Windows XP x86.
