### PR TITLE
Make it possible to retrieve information about the USB device that provides the serial port

### DIFF
--- a/src/cpp/jssc_SerialNativeInterface.h
+++ b/src/cpp/jssc_SerialNativeInterface.h
@@ -183,6 +183,14 @@ JNIEXPORT jintArray JNICALL Java_jssc_SerialNativeInterface_getLinesStatus
 JNIEXPORT jboolean JNICALL Java_jssc_SerialNativeInterface_sendBreak
   (JNIEnv *, jobject, jlong, jint);
 
+/*
+ * Class:     jssc_SerialNativeInterface
+ * Method:    getPortIdProduct
+ * Signature: (Ljava/lang/String;)Ljava/lang/String;
+ */
+JNIEXPORT jobjectArray JNICALL Java_jssc_SerialNativeInterface_getPortProperties
+  (JNIEnv *, jclass, jstring);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -469,4 +469,6 @@ public class SerialNativeInterface {
      * @since 0.8
      */
     public native boolean sendBreak(long handle, int duration);
+
+    public static native String[] getPortProperties(String portName);
 }

--- a/src/java/jssc/SerialPortList.java
+++ b/src/java/jssc/SerialPortList.java
@@ -25,7 +25,11 @@
 package jssc;
 
 import java.io.File;
+import java.io.FileReader;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
@@ -294,6 +298,77 @@ public class SerialPortList {
             return getWindowsPortNames(pattern, comparator);
         }
         return getUnixBasedPortNames(searchPath, pattern, comparator);
+    }
+
+    public static Map<String, String> getPortProperties(String portName) {
+        if(SerialNativeInterface.getOsType() == SerialNativeInterface.OS_LINUX) {
+            return getLinuxPortProperties(portName);
+        } else if(SerialNativeInterface.getOsType() == SerialNativeInterface.OS_MAC_OS_X) {
+            return getNativePortProperties(portName);
+        } else if(SerialNativeInterface.getOsType() == SerialNativeInterface.OS_WINDOWS){
+            // TODO
+            return new HashMap<String, String>();
+        } else {
+            return new HashMap<String, String>();
+        }
+    }
+
+    public static Map<String, String> getLinuxPortProperties(String portName) {
+        Map<String, String> props = new HashMap<String, String>();
+        try {
+            // portName has the format /dev/ttyUSB0
+            String dev = portName.split("/")[2];
+            File sysfsNode = new File("/sys/bus/usb-serial/devices/"+dev);
+
+            // resolve the symbolic link and store the resulting components in an array
+            String[] sysfsPath = sysfsNode.getCanonicalPath().split("/");
+
+            // walk the tree to the root
+            for (int i=sysfsPath.length-2; 0 < i; i--) {
+                String curPath = "/";
+                for (int j=1; j <= i; j++) {
+                    curPath += sysfsPath[j]+"/";
+                }
+
+                // look for specific attributes
+                String[] attribs = { "idProduct", "idVendor", "manufacturer", "product", "serial" };
+                for (int j=0; j < attribs.length; j++) {
+                    try {
+                        Scanner in = new Scanner(new FileReader(curPath+attribs[j]));
+                        // we treat the values just as strings
+                        props.put(attribs[j], in.next());
+                    } catch (Exception e) {
+                        // ignore the attribute
+                    }
+                }
+
+                // stop once we have at least one attribute
+                if (0 < props.size()) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            // nothing to do, return what we have so far
+        }
+        return props;
+    }
+
+    public static Map<String, String> getNativePortProperties(String portName) {
+        Map<String, String> props = new HashMap<String, String>();
+        try {
+            // use JNI functions to read those properties
+            String[] names = { "idProduct", "idVendor", "manufacturer", "product", "serial" };
+            String[] values = SerialNativeInterface.getPortProperties(portName);
+
+            for (int i=0; i < names.length; i++) {
+                if (values[i] != null) {
+                    props.put(names[i], values[i]);
+                }
+            }
+        } catch (Exception e) {
+            // nothing to do, return what we have so far
+        }
+        return props;
     }
 
     /**


### PR DESCRIPTION
getPortProperties() returns a map with keys and values as strings. The currently available keys are: idProduct (lowercase hexadecimal zero-padded to four digits), idVendor (as idProduct), manufacturer, product, serial. This is currently implemented for Linux and Mac OS X.
