### PR TITLE
Modify SerialPort to implement java.io.Closeable

### DIFF
--- a/src/main/java/org/scream3r/jssc/SerialPort.java
+++ b/src/main/java/org/scream3r/jssc/SerialPort.java
@@ -24,8 +24,10 @@
  */
 package org.scream3r.jssc;
 
+import java.io.Closeable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+
 import jssc.SerialNativeAccess;
 import jssc.SerialNativeInterface;
 
@@ -33,7 +35,7 @@ import jssc.SerialNativeInterface;
  *
  * @author scream3r
  */
-public class SerialPort {
+public class SerialPort implements Closeable {
 
     private SerialNativeInterface serialInterface;
     private SerialPortEventListener eventListener;
@@ -1079,11 +1081,15 @@ public class SerialPort {
     }
 
     /**
-     * Close port. This method deletes event listener first, then closes the port
+     * Close the serial port. Removes the event listener if one exists has been
+     * added, then closes the underlying native port.
      *
-     * @return If the operation is successfully completed, the method returns true, otherwise false
-     * 
+     * @return whether or not the operation has been successfully completed
+     *
      * @throws SerialPortException
+     *
+     * @deprecated
+     * @see #close()
      */
     public boolean closePort() throws SerialPortException {
         checkPortOpened("closePort()");
@@ -1096,6 +1102,20 @@ public class SerialPort {
             portOpened = false;
         }
         return returnValue;
+    }
+
+    /**
+     * Close the serial port. Removes the event listener if one exists has been
+     * added, then closes the underlying native port.
+     *
+     * @throws SerialPortException
+     */
+    public void close() throws SerialPortException {
+        boolean portClosed = closePort();
+        if(!portClosed){
+            throw new SerialPortException(portName, "close()",
+                    SerialPortException.TYPE_CANT_CLOSE_PORT);
+        }
     }
 
     private EventThread eventThread;

--- a/src/main/java/org/scream3r/jssc/SerialPortException.java
+++ b/src/main/java/org/scream3r/jssc/SerialPortException.java
@@ -24,11 +24,13 @@
  */
 package org.scream3r.jssc;
 
+import java.io.IOException;
+
 /**
  *
  * @author scream3r, vogt31337@googlemail.com
  */
-public class SerialPortException extends Exception {
+public class SerialPortException extends IOException {
 
     final static long serialVersionUID = 5843574354687324684l;
     
@@ -62,6 +64,10 @@ public class SerialPortException extends Exception {
      * @since 2.3.0
      */
     final public static String TYPE_INCORRECT_SERIAL_PORT = "Incorrect serial port";
+    /**
+     * @since 2.8.1
+     */
+    final public static String TYPE_CANT_CLOSE_PORT = "Can't close native port";
 
     private String portName;
     private String methodName;

--- a/src/main/java/org/scream3r/jssc/SerialPortTimeoutException.java
+++ b/src/main/java/org/scream3r/jssc/SerialPortTimeoutException.java
@@ -24,11 +24,13 @@
  */
 package org.scream3r.jssc;
 
+import java.io.IOException;
+
 /**
  *
  * @author scream3r, vogt31337@googlemail.com
  */
-public class SerialPortTimeoutException extends Exception {
+public class SerialPortTimeoutException extends IOException {
 
     final static long serialVersionUID = -1584357967321684324l;
     

--- a/src/test/java/org/scream3r/jssc/TestSerialPortRead.java
+++ b/src/test/java/org/scream3r/jssc/TestSerialPortRead.java
@@ -6,7 +6,6 @@
 package org.scream3r.jssc;
 
 import junit.framework.TestCase;
-import static junit.framework.TestCase.assertTrue;
 import org.junit.Assert;
 
 /**
@@ -34,7 +33,7 @@ public class TestSerialPortRead extends TestCase {
                 serialPort.openPort();//Open serial port
                 serialPort.setParams(9600, 8, 1, 0);//Set params.
                 byte[] buffer = serialPort.readBytes(10);//Read 10 bytes from serial port
-                serialPort.closePort();//Close serial port
+                serialPort.close();//Close serial port
             } catch (SerialPortException ex) {
                 System.out.println(ex);
             }

--- a/src/test/java/org/scream3r/jssc/TestSerialPortWrite.java
+++ b/src/test/java/org/scream3r/jssc/TestSerialPortWrite.java
@@ -36,7 +36,7 @@ public class TestSerialPortWrite extends TestCase {
                         SerialPort.STOPBITS_1,
                         SerialPort.PARITY_NONE);//Set params. Also you can set params by this string: serialPort.setParams(9600, 8, 1, 0);
                 serialPort.writeBytes("This is a test string".getBytes());//Write data to port
-                serialPort.closePort();//Close serial port
+                serialPort.close();//Close serial port
             } catch (SerialPortException ex) {
                 System.out.println(ex);
             }


### PR DESCRIPTION
Per #48 (and its dependency on #47), this patch causes `SerialPort` to implement `java.io.Closeable`. This permits the operation of general I/O-related components upon jSSC-provided serial ports. Importantly, this enables the use of Java 7 [try-with-resources](http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) statements with serial ports.
