### PR TITLE
use initialization-on-demand holder idiom

### DIFF
--- a/src/main/java/jssc/SerialNativeAccess.java
+++ b/src/main/java/jssc/SerialNativeAccess.java
@@ -38,16 +38,16 @@ import java.io.InputStreamReader;
 public class SerialNativeAccess {
     private int osType = -1;
     private static SerialNativeInterface sni = new SerialNativeInterface();
-    private static SerialNativeAccess instance = null;
-    
-    public static SerialNativeAccess getInstance() {
-        if (SerialNativeAccess.instance == null) {
-            SerialNativeAccess.instance = new SerialNativeAccess();
-        } 
-        return SerialNativeAccess.instance;
+
+    private static class LazyHolder {
+        private static final SerialNativeAccess INSTANCE = new SerialNativeAccess();
     }
     
-    public SerialNativeAccess() {
+    public static SerialNativeAccess getInstance() {
+        return LazyHolder.INSTANCE;
+    }
+    
+    private SerialNativeAccess() {
         String libFolderPath;
         String libName;
 


### PR DESCRIPTION
This gives us a highly efficient thread-safe "singleton" cache, without synchronization overhead...
(lecture: https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom)

The access modifier for the constructor was changed to private as this is normal for a singleton class.
