### PR TITLE
Update SerialPortList.java

### DIFF
--- a/src/java/jssc/SerialPortList.java
+++ b/src/java/jssc/SerialPortList.java
@@ -43,7 +43,7 @@ public class SerialPortList {
         serialInterface = new SerialNativeInterface();
         switch (SerialNativeInterface.getOsType()) {
             case SerialNativeInterface.OS_LINUX: {
-                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|RS-485|RS485|RS-232|RS232)[0-9]{1,3}");
+                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|RS-485|RS485|RS-232|RS232)");
                 PORTNAMES_PATH = "/dev/";
                 break;
             }

--- a/src/java/jssc/SerialPortList.java
+++ b/src/java/jssc/SerialPortList.java
@@ -43,7 +43,7 @@ public class SerialPortList {
         serialInterface = new SerialNativeInterface();
         switch (SerialNativeInterface.getOsType()) {
             case SerialNativeInterface.OS_LINUX: {
-                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO)[0-9]{1,3}");
+                PORTNAMES_REGEXP = Pattern.compile("(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|RS-485|RS485|RS-232|RS232)[0-9]{1,3}");
                 PORTNAMES_PATH = "/dev/";
                 break;
             }


### PR DESCRIPTION
Hello! Thanks for excellent serial port lib!
This small change in code allows detection of custom-named ports when using persistent udev rules that include interface type in port's name. Persistent rules is a good practice (even in one-port system, because if you will replug converter while port is opened, without rule you will often get ttyUSB1 name instead of previous ttyUSB0), and even Chineese manufactures (like waveshare) include udev-rules in their linux distros to provide easy-readable names like RS-485-serialNumberOfChip for interface converters.
Regex amount and number modificators ([0-9]{1,3}) can also be safely dropped - in linux by default all devices starting with "ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|RS-485|RS485|RS-232|RS232" are serial ports, removing a/n moidifiers will allow to get ports that include different marks after type (chip serial number, chip manufacturer id and so on)
