### PR TITLE
Adds InterruptedException management while reading serial port with timeout

### DIFF
--- a/src/java/jssc/SerialPort.java
+++ b/src/java/jssc/SerialPort.java
@@ -559,7 +559,7 @@ public class SerialPort {
                 Thread.sleep(0, 100);//Need to sleep some time to prevent high CPU loading
             }
             catch (InterruptedException ex) {
-                //Do nothing
+                throw new SerialPortException(portName, methodName, SerialPortException.TYPE_LISTENER_THREAD_INTERRUPTED);
             }
         }
         if(timeIsOut){


### PR DESCRIPTION
The waitBytesWithTimeout() method did not handle InterruptedExceptions.
As a result, a lot Thread.interrupt() attempts were consummed but not treated
while calling read with timeout methods.

This fix takes into account InterruptedExceptions and throws a
SerialPortException for each of them.