### PR TITLE
Allow to specify a library folder to avoid native lib unpacking.

### DIFF
--- a/src/java/jssc/SerialNativeInterface.java
+++ b/src/java/jssc/SerialNativeInterface.java
@@ -140,7 +140,12 @@ public class SerialNativeInterface {
             architecture = "arm" + floatStr;
         }
         
-        libFolderPath = libRootFolder + fileSeparator + ".jssc" + fileSeparator + osName;
+        String jsscLibPath = System.getProperty("jssc.library.path");
+        if (jsscLibPath != null) {
+            libFolderPath = jsscLibPath;
+        } else {
+            libFolderPath = libRootFolder + fileSeparator + ".jssc" + fileSeparator + osName;
+        }
         libName = "jSSC-" + libVersion + "_" + architecture;
         libName = System.mapLibraryName(libName);
 


### PR DESCRIPTION
On some circumstances you're not allowed to write to the user home or to load code by unpacking it.

This commit allows to specify a VM variable called "jssc.library.path" that is the path where JSSC will search for native libraries.
