### PR TITLE
MAC OS fix missing Silicon Labs CP210x USB to UART Bridge VCP Drivers

### DIFF
--- a/src/java/jssc/SerialPortList.java
+++ b/src/java/jssc/SerialPortList.java
@@ -53,7 +53,7 @@ public class SerialPortList {
                 break;
             }
             case SerialNativeInterface.OS_MAC_OS_X: {
-                PORTNAMES_REGEXP = Pattern.compile("tty.(serial|usbserial|usbmodem).*");
+                PORTNAMES_REGEXP = Pattern.compile("tty.(serial|usbserial|usbmodem|slab).*", Pattern.CASE_INSENSITIVE);
                 PORTNAMES_PATH = "/dev/";
                 break;
             }


### PR DESCRIPTION
Several applications are using CP210x USB to UART Bridge VCP Drivers, resulting on MAC OS X in a port named "/dev/tty.SLAB_USBtoUART". This ports doesn't get detected using the existing pattern to match serial port names. My small change will fix this.